### PR TITLE
Handle rides that don't have instructor_id

### DIFF
--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -98,8 +98,12 @@ class PylotonCycle:
 
             resp_summary = self.GetWorkoutSummaryById(workout_id)
             resp_workout = self.GetWorkoutById(workout_id)
-            instructor_id = resp_workout['ride']['instructor_id']
-            resp_instructor = self.GetInstructorById(instructor_id)
+
+            if 'instructor_id' in resp_workout['ride']:
+                instructor_id = resp_workout['ride']['instructor_id']
+                resp_instructor = self.GetInstructorById(instructor_id)
+            elif 'instructor' in resp_workout['ride']:
+                resp_instructor = {'name': resp_workout['ride']['instructor']['name']}
 
             resp_workout['overall_summary'] = resp_summary
             try:


### PR DESCRIPTION
I was noticing that some rides come back as such:
```
"ride": {
		"id": "00000000000000000000000000000000",
		"is_archived": false,
		"instructor": {
			"name": "JUST RIDE",
			"image_url": "https://s3.amazonaws.com/peloton-ride-images/just-ride.png"
		},
		"title": "5 min 1 sec Just Ride",
		"scheduled_start_time": 1587563526,
		"duration": 301
	}
```
Since there is no `instructor_id`, there would be a KeyError here.  This remedies that situation!