### PR TITLE
Sync license tag with actual license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     url='https://github.com/justmedude/pylotoncycle',
     author='Vikram Adukia',
     author_email='github@fireitup.net',
-    license='MIT',
+    license='BSD',
     packages=['pylotoncycle'],
     install_requires=['requests'],
 


### PR DESCRIPTION
The [license](https://github.com/justmedude/pylotoncycle/blob/master/LICENSE) is BSD and not MIT.