### PR TITLE
Workout summary URL update

### DIFF
--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -128,7 +128,7 @@ class PylotonCycle:
         return workouts_info
 
     def GetWorkoutSummaryById(self, workout_id):
-        url = '%s/api/workout/%s/summary' % (self.base_url, workout_id)
+        url = '%s/api/workout/%s' % (self.base_url, workout_id)
         resp = self.GetUrl(url)
         return resp
 


### PR DESCRIPTION
appending `/summary` to the url now gives a `404`.