### PR TITLE
Add workouts_to_ics.py which can export Peloton workouts to ICS format

### DIFF
--- a/examples/tests/test_workouts_to_ics.py
+++ b/examples/tests/test_workouts_to_ics.py
@@ -1,5 +1,7 @@
 import unittest
-from workouts_to_ics import generate_description
+from datetime import datetime, timedelta
+from icalendar import Calendar, Event
+from workouts_to_ics import generate_description, convert_to_ical
 
 
 class TestGenerateDescription(unittest.TestCase):
@@ -67,6 +69,107 @@ Description: There’s nothing more satisfying than leaving a hill in your dust.
         description, error = generate_description(workout, True)
         self.assertEqual(description, expected_description)
         self.assertIsInstance(error, Exception)
+
+
+
+class TestConvertToICal(unittest.TestCase):
+
+    def test_convert_to_ical_regular_ride(self):
+        """
+        Test case to verify the conversion of a regular ride workout to iCalendar format.
+        """
+        workout = {
+            "created_at": 1672946636,
+            "ride": {
+                "title": "20 min Climb Ride",
+                "duration": 1273,
+                "instructor": {
+                    "name": "Emma Lovewell"
+                }
+            },
+            "instructor_name": "Emma Lovewell",
+            "fitness_discipline": "cycling",
+            "leaderboard_rank": 2375,
+            "total_leaderboard_users": 10267,
+            "ftp_info": {
+                "ftp": 213
+            }
+        }
+
+        expected_ical_data = self._generate_expected_ical_data(workout)
+
+        workouts = [workout]
+        ical_data = convert_to_ical(workouts)
+
+        self.assertEqual(ical_data, expected_ical_data)
+
+    def test_convert_to_ical_just_ride(self):
+        """
+        Test case to verify the conversion of a 'Just Ride' workout to iCalendar format.
+        """
+        workout = {
+            "created_at": 1672946636,
+            "ride": {
+                "title": "21 min Just Ride",
+                "duration": 1273,
+                "instructor": {
+                    "name": "JUST RIDE"
+                }
+            },
+            "instructor_name": "JUST RIDE",
+            "fitness_discipline": "cycling",
+            "ftp_info": {
+                "ftp": None,
+                "ftp_source": None,
+                "ftp_workout_id": None
+            }
+        }
+
+        expected_ical_data = self._generate_expected_ical_data(workout)
+
+        workouts = [workout]
+        ical_data = convert_to_ical(workouts)
+
+        self.assertEqual(ical_data, expected_ical_data)
+
+    def _generate_expected_ical_data(self, workout):
+        """
+        Generate the expected iCalendar data for a given workout.
+
+        Args:
+            workout (dict): The workout data.
+
+        Returns:
+            str: The expected iCalendar data.
+        """
+        cal = Calendar()
+        cal.add('VERSION', '2.0')
+        cal.add('PRODID', '-//pylotoncycle workouts_to_ics.py//EN')
+        cal.add('X-WR-CALNAME', 'Peloton Workouts')
+
+        created_at = datetime.fromtimestamp(int(workout['created_at']))
+        end_time = created_at + timedelta(minutes=workout['ride']['duration'] // 60)
+        workout_title = workout['ride'].get('title', 'Untitled')
+        instructor_name = workout['instructor_name']
+
+        if instructor_name == "JUST RIDE":
+            workout_len = workout['ride']['duration'] // 60
+            title = f"{workout_len} minute Just Ride"
+        else:
+            title = f"{workout_title} with {instructor_name}"
+
+        event = Event()
+        event.add('summary', title.encode('utf-8'))
+        event.add('dtstart', created_at)
+        event.add('dtend', end_time)
+
+        description, _ = generate_description(workout)
+        event.add('description', description.encode('utf-8'))
+
+        cal.add_component(event)
+        expected_ical_data = cal.to_ical().decode('utf-8')
+
+        return expected_ical_data
 
 
 if __name__ == '__main__':

--- a/examples/tests/test_workouts_to_ics.py
+++ b/examples/tests/test_workouts_to_ics.py
@@ -1,0 +1,73 @@
+import unittest
+from workouts_to_ics import generate_description
+
+
+class TestGenerateDescription(unittest.TestCase):
+
+    def test_just_ride_description(self):
+        """
+        Test case to verify the description generated for a 'Just Ride' workout.
+        """
+        workout = {
+            "ride": {
+                "title": "21 min Just Ride",
+                "duration": 1273,
+                "instructor": {
+                    "name": "JUST RIDE",
+                    "image_url": "https://s3.amazonaws.com/peloton-ride-images/just-ride-indoor.png"
+                }
+            },
+            "instructor_name": "JUST RIDE",
+            "leaderboard_rank": None,
+            "total_leaderboard_users": None,
+            "ftp_info": {
+                "ftp": None,
+                "ftp_source": None,
+                "ftp_workout_id": None
+            }
+        }
+        expected_description = "21 minute Just Ride"
+        description, error = generate_description(workout)
+        self.assertEqual(description, expected_description)
+        self.assertIsNone(error)
+
+    def test_regular_ride_description(self):
+        """
+        Test case to verify the description generated for a regular ride workout.
+        """
+        workout = {
+            "ride": {
+                "title": "20 min Climb Ride",
+                "difficulty_estimate": 7.7326,
+                "description": "There’s nothing more satisfying than leaving a hill in your dust.",
+            },
+            "instructor_name": "Emma Lovewell",
+            "leaderboard_rank": 2375,
+            "total_leaderboard_users": 10267,
+            "ftp_info": {
+                "ftp": 213
+            }
+        }
+        expected_description = """Ride Title: 20 min Climb Ride
+Difficulty: 7.7326
+Leaderboard: 2375/10267 23.13%
+FTP: 213
+Description: There’s nothing more satisfying than leaving a hill in your dust."""
+        description, error = generate_description(workout)
+        self.assertEqual(description, expected_description)
+        self.assertIsNone(error)
+
+    def test_unknown_description(self):
+        """
+        Test case to verify we get an error back for an invalid workout.
+        """
+        workout = {"ride": {}, "instructor_name": "", "ftp_info": { "ftp": None }}
+        expected_description = "Unknown Description"
+        # Pass in silent=True to generate_description since we expect it to raise an exception
+        description, error = generate_description(workout, True)
+        self.assertEqual(description, expected_description)
+        self.assertIsInstance(error, Exception)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/examples/workouts_to_ics.py
+++ b/examples/workouts_to_ics.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+"""
+workouts_to_ics.py
+Example usage of using pylotoncycle to pull in your workouts and output
+them to a ICS iCalendar (RFC 2445) file.
+"""
+import os
+import sys
+import traceback
+import argparse
+import json
+from datetime import datetime, timedelta
+from icalendar import Calendar, Event
+import pylotoncycle
+
+def parse_command_line():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--username', help='Peloton username')
+    parser.add_argument('--password', help='Peloton password')
+    parser.add_argument('--num_results', type=int, default=10, help='Number of recent workouts to fetch')
+    parser.add_argument('--input_json', help='Path to input JSON file containing workouts')
+    parser.add_argument('--output_json', help='Path to output JSON file for the fetched workouts')
+    parser.add_argument('--calendar_name', default='Peloton Workouts', help='Calendar name')
+    parser.add_argument('--debug', action='store_true', help='Enable debug mode')
+    return parser.parse_args()
+
+
+def generate_description(workout):
+    ride = workout['ride']
+    leaderboard_rank = workout.get('leaderboard_rank', 'N/A')
+    total_leaderboard_users = workout.get('total_leaderboard_users', 'N/A')
+    ftp = workout['ftp_info'].get('ftp', 'N/A')
+
+    instructor_name = workout['instructor_name']
+    try:
+        if instructor_name == "JUST RIDE":
+            workout_len = workout['ride']['duration'] // 60
+            description = f"{workout_len} minute Just Ride"
+        else:
+            description = f"Ride Title: {ride.get('title', 'N/A')}\n"
+            description += f"Difficulty: {ride.get('difficulty_estimate', 'N/A')}\n"
+            if leaderboard_rank != 0 and total_leaderboard_users:
+                percentile = leaderboard_rank / total_leaderboard_users * 100
+                description += f"Leaderboard: {leaderboard_rank}/{total_leaderboard_users} {percentile:.2f}%\n"
+            description += f"FTP: {ftp}\n"
+            description += f"Description: {ride.get('description', 'N/A')}"
+        return description, None
+    except Exception as err:
+        print(f"Error: {err}", file=sys.stderr)
+        traceback.print_exc()
+        return "Unknown Description", err
+
+
+def convert_to_ical(workouts, calendar_name='Peloton Workouts'):
+    cal = Calendar()
+    cal.add('VERSION', '2.0')
+    cal.add('PRODID', '-//pylotoncycle workouts_to_ics.py//EN')
+    cal.add('X-WR-CALNAME', calendar_name)
+
+    for workout in workouts:
+        created_at = datetime.fromtimestamp(int(workout['created_at']))
+        end_time = created_at + timedelta(minutes=workout['ride']['duration'] // 60)
+        workout_type = workout['fitness_discipline']
+        ride = workout['ride']
+        workout_title = ride.get('title', 'Untitled')
+        instructor_name = workout['instructor_name']
+        if instructor_name == "JUST RIDE":
+            workout_len = workout['ride']['duration'] // 60
+            title = f"{workout_len} minute Just Ride"
+        else:
+            title = f"{workout_title} with {instructor_name}"
+
+        start_time = created_at
+        end_time = created_at + timedelta(minutes=workout['ride']['duration'] // 60)
+
+        event = Event()
+        # Add image as ATTACH if there is one
+        image_url = ride.get('image_url', None)
+        if image_url:
+            event.add('attach', image_url)
+        event.add('summary', title.encode('utf-8'))
+        event.add('dtstart', start_time)
+        event.add('dtend', end_time)
+        description, err = generate_description(workout)
+        event.add('description', description.encode('utf-8'))
+
+        cal.add_component(event)
+
+    ical_data = cal.to_ical().decode('utf-8')
+
+    return ical_data
+
+
+if __name__ == "__main__":
+    args = parse_command_line()
+    debug_mode = args.debug
+
+    username = args.username or os.environ.get('PELOTON_USERNAME')
+    password = args.password or os.environ.get('PELOTON_PASSWORD')
+    input_json = args.input_json
+    output_json = args.output_json
+
+    if input_json:
+        with open(input_json) as f:
+            workouts = json.load(f)
+    else:
+        if not username or not password:
+            raise ValueError("Peloton username and password are required.")
+        print("Attempting to connect...", file=sys.stderr))
+        conn = pylotoncycle.PylotonCycle(username, password)
+        print("Connected.", file=sys.stderr))
+        workouts = conn.GetRecentWorkouts(num_workouts=args.num_results)
+
+    if output_json:
+        with open(output_json, 'w') as f:
+            json.dump(workouts, f, indent=4)
+
+    ical_data = convert_to_ical(workouts, calendar_name=args.calendar_name)
+
+    # Print the generated iCalendar data to stdout
+    print(ical_data)
+

--- a/examples/workouts_to_ics.py
+++ b/examples/workouts_to_ics.py
@@ -2,8 +2,18 @@
 
 """
 workouts_to_ics.py
-Example usage of using pylotoncycle to pull in your workouts and output
-them to a ICS iCalendar (RFC 2445) file.
+Convert Peloton workouts to iCalendar (RFC 2445) format.
+
+This script utilizes the pylotoncycle library to fetch recent workouts and
+outputs them to an ICS file that can be imported into calendar applications.
+
+Example usage:
+    python workouts_to_ics.py --username <username> --password <password>
+
+Dependencies:
+    - pylotoncycle
+    - icalendar
+
 """
 import os
 import sys
@@ -15,6 +25,13 @@ from icalendar import Calendar, Event
 import pylotoncycle
 
 def parse_command_line():
+    """
+    Parse command-line arguments.
+
+    Returns:
+        argparse.Namespace: An object containing parsed command-line arguments.
+
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument('--username', help='Peloton username')
     parser.add_argument('--password', help='Peloton password')
@@ -26,7 +43,17 @@ def parse_command_line():
     return parser.parse_args()
 
 
-def generate_description(workout):
+def generate_description(workout, silent=False):
+    """
+    Generate the description for a workout.
+
+    Args:
+        workout (dict): The workout data.
+
+    Returns:
+        tuple: A tuple containing the generated description (str) and the error (Exception) if any.
+
+    """
     ride = workout['ride']
     leaderboard_rank = workout.get('leaderboard_rank', 'N/A')
     total_leaderboard_users = workout.get('total_leaderboard_users', 'N/A')
@@ -47,12 +74,24 @@ def generate_description(workout):
             description += f"Description: {ride.get('description', 'N/A')}"
         return description, None
     except Exception as err:
-        print(f"Error: {err}", file=sys.stderr)
-        traceback.print_exc()
+        if not silent:
+            print(f"Error: {err}", file=sys.stderr)
+            traceback.print_exc()
         return "Unknown Description", err
 
 
 def convert_to_ical(workouts, calendar_name='Peloton Workouts'):
+    """
+    Convert workouts to iCalendar format.
+
+    Args:
+        workouts (list): List of workout data.
+        calendar_name (str, optional): Name of the calendar. Defaults to 'Peloton Workouts'.
+
+    Returns:
+        str: The generated iCalendar data.
+
+    """
     cal = Calendar()
     cal.add('VERSION', '2.0')
     cal.add('PRODID', '-//pylotoncycle workouts_to_ics.py//EN')

--- a/examples/workouts_to_ics.py
+++ b/examples/workouts_to_ics.py
@@ -107,9 +107,9 @@ if __name__ == "__main__":
     else:
         if not username or not password:
             raise ValueError("Peloton username and password are required.")
-        print("Attempting to connect...", file=sys.stderr))
+        print("Attempting to connect...", file=sys.stderr)
         conn = pylotoncycle.PylotonCycle(username, password)
-        print("Connected.", file=sys.stderr))
+        print("Connected.", file=sys.stderr)
         workouts = conn.GetRecentWorkouts(num_workouts=args.num_results)
 
     if output_json:


### PR DESCRIPTION
- Have only tested with cycling workouts
- By default it will get the 10 most recent workouts only.  Use --num_results to increase this.
- TODO: Cache local copies of the workouts in JSON so we don't need to get them again when checking for new workouts.