### PR TITLE
Changing Auth Endpoint URL to fix changes to the API

### DIFF
--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -31,7 +31,7 @@ class PylotonCycle:
         self.login(username, password)
 
     def login(self, username, password):
-        auth_login_url = "%s/auth/login" % self.base_url
+        auth_login_url = "%s/auth/login?=" % self.base_url
         auth_payload = {"username_or_email": username, "password": password}
         headers = {"Content-Type": "application/json", "User-Agent": "pyloton"}
         resp = self.s.post(


### PR DESCRIPTION
Sourced from [another project](https://github.com/philosowaffle/peloton-to-garmin/issues/795#issuecomment-3470920257)

Changing the Auth URL from `/auth/login` to `/auth/login?=` allows basic auth without OAuth plumbing.

Fixes #22 