### PR TITLE
feat(auth): migrate to OAuth 2.0 PKCE authentication flow

### DIFF
--- a/examples/workouts_to_ics.py
+++ b/examples/workouts_to_ics.py
@@ -84,6 +84,11 @@ def convert_to_ical(workouts, calendar_name='Peloton Workouts'):
     """
     Convert workouts to iCalendar format.
 
+    TODO: Support excluding workouts shorter than a specified length (Example: skip short cooldown workouts)
+    TODO: Support local cached copies of the workouts (but note they change over time because
+          the leaderboard gets updated as more do the ride.)
+    TODO: Optionally support iCalendar category field
+
     Args:
         workouts (list): List of workout data.
         calendar_name (str, optional): Name of the calendar. Defaults to 'Peloton Workouts'.

--- a/pylotoncycle/__init__.py
+++ b/pylotoncycle/__init__.py
@@ -1,5 +1,4 @@
 from .pylotoncycle import PylotonCycle
-from .parser import *
-
+from .parser import ParseCyclingMetrics, ParseOutdoorRunMetrics
 
 __all__ = ["PylotonCycle", "ParseCyclingMetrics", "ParseOutdoorRunMetrics"]

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -3,8 +3,14 @@
 
 # https://app.swaggerhub.com/apis/DovOps/peloton-unofficial-api/0.2.3
 
-# import pprint
+import base64
+import hashlib
+import json
+import secrets
+import urllib.parse
+
 import requests
+from bs4 import BeautifulSoup
 
 
 class PelotonLoginException(Exception):
@@ -30,20 +36,164 @@ class PylotonCycle:
 
         self.login(username, password)
 
-    def login(self, username, password):
-        auth_login_url = "%s/auth/login?=" % self.base_url
-        auth_payload = {"username_or_email": username, "password": password}
-        headers = {"Content-Type": "application/json", "User-Agent": "pyloton"}
-        resp = self.s.post(
-            auth_login_url, json=auth_payload, headers=headers, timeout=10
-        ).json()
+    # OAuth 2.0 PKCE constants (Auth0-based)
+    AUTH_DOMAIN = "auth.onepeloton.com"
+    CLIENT_ID = "WVoJxVDdPoFx4RNewvvg6ch2mZ7bwnsM"
+    REDIRECT_URI = "https://members.onepeloton.com/callback"
+    AUDIENCE = "https://api.onepeloton.com/"
+    SCOPE = "offline_access openid peloton-api.members:default"
+    AUTH0_CLIENT = base64.b64encode(
+        json.dumps({"name": "auth0.js-ulp", "version": "9.14.3"}).encode()
+    ).decode()
 
-        if ("status" in resp) and (resp["status"] == 401):
+    def login(self, username, password):
+        # Step 1: Generate PKCE parameters
+        code_verifier = secrets.token_urlsafe(48)[:64]
+        code_challenge = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(code_verifier.encode()).digest()
+            )
+            .rstrip(b"=")
+            .decode()
+        )
+        state = secrets.token_urlsafe(24)[:32]
+        nonce = secrets.token_urlsafe(24)[:32]
+
+        # Step 2: GET /authorize to start the OAuth flow and get CSRF token
+        authorize_url = f"https://{self.AUTH_DOMAIN}/authorize"
+        authorize_params = {
+            "response_type": "code",
+            "code_challenge_method": "S256",
+            "code_challenge": code_challenge,
+            "client_id": self.CLIENT_ID,
+            "redirect_uri": self.REDIRECT_URI,
+            "scope": self.SCOPE,
+            "audience": self.AUDIENCE,
+            "state": state,
+            "nonce": nonce,
+        }
+        resp = self.s.get(authorize_url, params=authorize_params, timeout=30)
+        resp.raise_for_status()
+
+        # Extract Auth0's internal state from the final redirect URL
+        parsed_url = urllib.parse.urlparse(resp.url)
+        url_params = urllib.parse.parse_qs(parsed_url.query)
+        auth0_state = url_params.get("state", [None])[0]
+        if auth0_state:
+            state = auth0_state
+
+        csrf_token = self.s.cookies.get("_csrf")
+        if not csrf_token:
             raise PelotonLoginException(
-                resp["message"] if ("message" in resp) else "Login Failed"
+                "Failed to obtain CSRF token from Auth0"
             )
 
-        self.userid = resp["user_id"]
+        # Step 3: POST credentials to /usernamepassword/login
+        login_url = f"https://{self.AUTH_DOMAIN}/usernamepassword/login"
+        login_payload = {
+            "client_id": self.CLIENT_ID,
+            "redirect_uri": self.REDIRECT_URI,
+            "tenant": "peloton-prod",
+            "response_type": "code",
+            "scope": self.SCOPE,
+            "audience": self.AUDIENCE,
+            "state": state,
+            "nonce": nonce,
+            "connection": "pelo-user-password",
+            "username": username,
+            "password": password,
+            "_csrf": csrf_token,
+            "sso": "true",
+            "_intstate": "deprecated",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        login_headers = {
+            "Auth0-Client": self.AUTH0_CLIENT,
+            "Content-Type": "application/json",
+        }
+        resp = self.s.post(
+            login_url, json=login_payload, headers=login_headers, timeout=30
+        )
+        if resp.status_code != 200:
+            raise PelotonLoginException(
+                f"Login failed (HTTP {resp.status_code}): {resp.text}"
+            )
+
+        # Step 4: Parse the HTML response for hidden form fields
+        soup = BeautifulSoup(resp.text, "html.parser")
+        form = soup.find("form")
+        if not form:
+            raise PelotonLoginException(
+                "Login failed: no callback form in response (bad credentials?)"
+            )
+
+        form_action = form.get("action")
+        # Resolve relative URLs against the Auth0 domain
+        if form_action and form_action.startswith("/"):
+            form_action = f"https://{self.AUTH_DOMAIN}{form_action}"
+        form_data = {}
+        for inp in form.find_all("input", {"type": "hidden"}):
+            name = inp.get("name")
+            value = inp.get("value", "")
+            if name:
+                form_data[name] = value
+
+        # Step 5: POST the hidden form to get the authorization code
+        # Disable auto-redirect so we can capture the code from the
+        # Location header
+        resp = self.s.post(
+            form_action, data=form_data, allow_redirects=False, timeout=30
+        )
+
+        # Follow redirects manually to find the one with ?code=
+        auth_code = None
+        max_redirects = 10
+        while resp.is_redirect and max_redirects > 0:
+            location = resp.headers.get("Location", "")
+            # Resolve relative redirect URLs
+            if location.startswith("/"):
+                location = f"https://{self.AUTH_DOMAIN}{location}"
+            parsed = urllib.parse.urlparse(location)
+            query_params = urllib.parse.parse_qs(parsed.query)
+            if "code" in query_params:
+                auth_code = query_params["code"][0]
+                break
+            resp = self.s.get(location, allow_redirects=False, timeout=30)
+            max_redirects -= 1
+
+        if not auth_code:
+            raise PelotonLoginException(
+                "Failed to obtain authorization code from OAuth callback"
+            )
+
+        # Step 6: Exchange authorization code for access token
+        token_url = f"https://{self.AUTH_DOMAIN}/oauth/token"
+        token_payload = {
+            "grant_type": "authorization_code",
+            "client_id": self.CLIENT_ID,
+            "code": auth_code,
+            "code_verifier": code_verifier,
+            "redirect_uri": self.REDIRECT_URI,
+        }
+        resp = self.s.post(token_url, json=token_payload, timeout=30)
+        resp.raise_for_status()
+        token_data = resp.json()
+
+        access_token = token_data.get("access_token")
+        if not access_token:
+            raise PelotonLoginException("No access_token in token response")
+
+        # Step 7: Set Bearer token for all subsequent API calls
+        self.s.headers.update(
+            {
+                "Authorization": f"Bearer {access_token}",
+            }
+        )
+
+        # Get user_id from /api/me (no longer returned by login response)
+        me = self.GetMe()
+        self.userid = me["id"]
 
     def GetMe(self):
         url = "%s/api/me" % self.base_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+beautifulsoup4

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pylotoncycle",
-    version="0.9.0",
+    version="0.9.1",
     description="Module to access your Peloton workout data",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -14,7 +14,7 @@ setuptools.setup(
     author_email="github@fireitup.net",
     license="BSD",
     packages=["pylotoncycle"],
-    install_requires=["requests"],
+    install_requires=["requests", "beautifulsoup4"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Replace legacy username/password login with Auth0 OAuth 2.0 PKCE flow:

- Add PKCE code verifier/challenge generation

- Implement multi-step OAuth authentication

- Add Bearer token authorization for API requests

- Add beautifulsoup4 dependency for HTML form parsing

Fixes: Remove star imports in __init__.py (flake8 F403/F405)