### PR TITLE
Add auth exception hierarchy

### DIFF
--- a/examples/tests/test_auth_exceptions.py
+++ b/examples/tests/test_auth_exceptions.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import patch
+import importlib
+
+import requests
+
+from pylotoncycle import PelotonAuthError
+from pylotoncycle.AutoRefreshingSession import AutoRefreshingSession
+
+auth_session_module = importlib.import_module(
+    "pylotoncycle.AutoRefreshingSession"
+)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+
+    def json(self):
+        return self._json_data
+
+
+class TestAutoRefreshingSession(unittest.TestCase):
+    def _make_session(self, **kwargs):
+        defaults = {
+            "username": "user",
+            "password": "pass",
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "client_id": "client",
+            "redirect_uri": "https://example.com/callback",
+            "token_url": "https://example.com/token",
+        }
+        defaults.update(kwargs)
+        return AutoRefreshingSession(**defaults)
+
+    def test_login_without_credentials_raises_auth_error(self):
+        session = self._make_session(username=None, password=None)
+
+        with self.assertRaises(PelotonAuthError):
+            session._login()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_login_with_non_200_raises_auth_error(self, mock_post):
+        mock_post.return_value = FakeResponse(status_code=400)
+        session = self._make_session()
+
+        with self.assertRaises(PelotonAuthError):
+            session._login()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_refresh_token_falls_back_to_login_failure(self, mock_post):
+        mock_post.return_value = FakeResponse(status_code=400)
+        session = self._make_session(refresh_token="refresh-token")
+
+        with self.assertRaises(PelotonAuthError):
+            session._refresh_access_token()
+
+    @patch.object(auth_session_module.requests, "post")
+    @patch.object(requests.Session, "request")
+    def test_request_401_wraps_refresh_failure(
+        self, mock_super_request, mock_post
+    ):
+        mock_super_request.return_value = FakeResponse(status_code=401)
+        mock_post.return_value = FakeResponse(status_code=400)
+        session = self._make_session(refresh_token="refresh-token")
+
+        with self.assertRaises(PelotonAuthError):
+            session.request("GET", "https://example.com/api")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pylotoncycle/AutoRefreshingSession.py
+++ b/pylotoncycle/AutoRefreshingSession.py
@@ -1,5 +1,7 @@
 import requests
 
+from .exceptions import PelotonAuthError
+
 
 class AutoRefreshingSession(requests.Session):
     """
@@ -61,13 +63,15 @@ class AutoRefreshingSession(requests.Session):
                 # print(f"Token refresh failed: {e}")
                 # If refresh fails, we return the original 401 response
                 # so the caller knows authentication is truly broken.
-                raise Exception(f"Could not obtain a new bearer token. {e}")
+                raise PelotonAuthError(
+                    f"Could not obtain a new bearer token. {e}"
+                ) from e
 
         return response
 
     def _login(self):
         if not self.username or not self.password:
-            raise Exception(
+            raise PelotonAuthError(
                 "Could not obtain a new bearer token. No login credentials provided. Update your refresh token."
             )
         # print ("Attempting using Username/Password")
@@ -81,7 +85,7 @@ class AutoRefreshingSession(requests.Session):
         resp = requests.post(self.token_url, json=payload, timeout=10)
 
         if resp.status_code != 200:
-            raise Exception(
+            raise PelotonAuthError(
                 "Could not obtain a new bearer token. If using login credentials ensure they are correct. If using a refresh token please update it."
             )
 
@@ -115,7 +119,12 @@ class AutoRefreshingSession(requests.Session):
         resp = requests.post(self.token_url, json=payload, timeout=10)
 
         if resp.status_code != 200:
-            self._login()
+            try:
+                self._login()
+            except PelotonAuthError as e:
+                raise PelotonAuthError(
+                    "Could not refresh access token and fallback login failed."
+                ) from e
             return
         data = resp.json()
         data.update(

--- a/pylotoncycle/__init__.py
+++ b/pylotoncycle/__init__.py
@@ -1,12 +1,16 @@
 from .pylotoncycle import PylotonCycle
 from .parser import *
 from .AutoRefreshingSession import AutoRefreshingSession
+from .exceptions import PelotonAuthError, PelotonAPIError, PylotonCycleError
 
 __version__ = "0.9.1"
 
 __all__ = [
     "PylotonCycle",
     "AutoRefreshingSession",
+    "PylotonCycleError",
+    "PelotonAuthError",
+    "PelotonAPIError",
     "ParseCyclingMetrics",
     "ParseOutdoorRunMetrics",
 ]

--- a/pylotoncycle/exceptions.py
+++ b/pylotoncycle/exceptions.py
@@ -1,0 +1,10 @@
+class PylotonCycleError(Exception):
+    """Base exception for pylotoncycle."""
+
+
+class PelotonAuthError(PylotonCycleError):
+    """Raised when authentication or token refresh fails."""
+
+
+class PelotonAPIError(PylotonCycleError):
+    """Raised when the API returns an unexpected response."""

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -4,9 +4,10 @@
 # https://app.swaggerhub.com/apis/DovOps/peloton-unofficial-api/0.2.3
 
 from .AutoRefreshingSession import AutoRefreshingSession
+from .exceptions import PelotonAuthError
 
 
-class PelotonLoginException(Exception):
+class PelotonLoginException(PelotonAuthError):
     pass
 
 


### PR DESCRIPTION
Introduce a small exception hierarchy for auth/session failures, wire the session and client code to use it, and add focused tests for the new behavior.