### PR TITLE
Handle workouts without instructor fields

### DIFF
--- a/examples/tests/test_pylotoncycle.py
+++ b/examples/tests/test_pylotoncycle.py
@@ -1,0 +1,24 @@
+import unittest
+
+from pylotoncycle import PylotonCycle
+
+
+class TestPylotonCycle(unittest.TestCase):
+    def test_recent_workouts_handles_missing_instructor_fields(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.GetWorkoutMetricsById = lambda workout_id: {"x": 1}
+        client.GetWorkoutById = lambda workout_id: {
+            "ride": {"title": "Test Ride", "duration": 600},
+            "instructor_name": None,
+        }
+        client.GetInstructorById = lambda instructor_id: {"name": "Ignored"}
+        client.GetWorkoutList = lambda num_workouts=None: [{"id": "w1"}]
+
+        result = PylotonCycle.GetRecentWorkouts(client, num_workouts=1)
+
+        self.assertIsNone(result[0]["instructor_name"])
+        self.assertEqual(result[0]["performance_graph"], {"x": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -126,6 +126,7 @@ class PylotonCycle:
             workout_id = i["id"]
             performance_graph = self.GetWorkoutMetricsById(workout_id)
             resp_workout = self.GetWorkoutById(workout_id)
+            resp_instructor = {"name": None}
 
             if "instructor_id" in resp_workout["ride"]:
                 instructor_id = resp_workout["ride"]["instructor_id"]


### PR DESCRIPTION
Initialize the instructor payload before checking workout ride metadata so workouts that lack both instructor_id and instructor do not raise an UnboundLocalError. Adds a focused regression test for that payload shape.