### PR TITLE
Add TestPyPI snapshot workflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Check formatting
         run: |
-          black --check .
+          black --check --diff .
 
       - name: Run tests
         run: |

--- a/.github/workflows/publish-testpypi-snapshot.yml
+++ b/.github/workflows/publish-testpypi-snapshot.yml
@@ -1,0 +1,44 @@
+name: Publish TestPyPI Snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: "Base version for the dev snapshot"
+        required: false
+        default: "0.9.2"
+
+jobs:
+  build-n-publish:
+    name: Build and publish TestPyPI snapshot
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set snapshot version
+        run: |
+          VERSION="${{ inputs.base_version }}.dev${GITHUB_RUN_NUMBER}"
+          python scripts/set_version.py "$VERSION"
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.test_pypi_password }}
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Show published version
+        run: |
+          echo "Published pylotoncycle $VERSION to TestPyPI"

--- a/scripts/set_version.py
+++ b/scripts/set_version.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+
 import re
 import sys
 from pathlib import Path

--- a/scripts/set_version.py
+++ b/scripts/set_version.py
@@ -4,7 +4,6 @@ import re
 import sys
 from pathlib import Path
 
-
 VERSION_PATTERN = re.compile(r'(__version__\s*=\s*")([^"]+)(")')
 SETUP_VERSION_PATTERN = re.compile(r'(version\s*=\s*")([^"]+)(")')
 

--- a/scripts/set_version.py
+++ b/scripts/set_version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import re
+import sys
+from pathlib import Path
+
+
+VERSION_PATTERN = re.compile(r'(__version__\s*=\s*")([^"]+)(")')
+SETUP_VERSION_PATTERN = re.compile(r'(version\s*=\s*")([^"]+)(")')
+
+
+def replace_version(path, pattern, version):
+    text = path.read_text(encoding="utf-8")
+    updated, count = pattern.subn(rf"\g<1>{version}\g<3>", text, count=1)
+    if count != 1:
+        raise RuntimeError(
+            f"Expected to update exactly one version in {path}"
+        )
+    path.write_text(updated, encoding="utf-8")
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: scripts/set_version.py <version>")
+
+    version = sys.argv[1]
+    replace_version(Path("setup.py"), SETUP_VERSION_PATTERN, version)
+    replace_version(
+        Path("pylotoncycle/__init__.py"), VERSION_PATTERN, version
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a manual workflow_dispatch workflow for publishing unique dev snapshot builds to TestPyPI. The workflow derives a PEP 440 dev version from a base version input and GITHUB_RUN_NUMBER, updates setup.py and pylotoncycle/__init__.py only inside the CI workspace, builds with python -m build, and publishes to TestPyPI using the existing test_pypi_password secret.

Validation:
- python3 scripts/set_version.py 0.9.2.dev999 updated both version files, then was restored to 0.9.1
- python3 -m black --check .
- python3 -m unittest discover -s examples/tests -p 'test_*.py'
- python3 -m build