### PR TITLE
Update GitHub Actions runtime versions

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish-testpypi-snapshot.yml
+++ b/.github/workflows/publish-testpypi-snapshot.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/publish-to-main-pypi.yml
+++ b/.github/workflows/publish-to-main-pypi.yml
@@ -9,9 +9,9 @@ jobs:
     name: Build and publish Python distributions to PyPi
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install setuptools and wheel
@@ -22,6 +22,6 @@ jobs:
       run: |
         python3 setup.py sdist bdist_wheel
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -8,9 +8,9 @@ jobs:
     name: Build and publish Python distributions to TestPyPi
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install setuptools and wheel
@@ -21,7 +21,7 @@ jobs:
       run: |
         python3 setup.py sdist bdist_wheel
     - name: Publist distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Updates GitHub Actions workflow dependencies to Node 24-compatible major versions:

- actions/checkout@v6
- actions/setup-python@v6
- pypa/gh-action-pypi-publish@release/v1 in the older PyPI release workflows

Also updates the TestPyPI release workflow input from repository_url to repository-url to match the v1 publish action.

Validation:
- python3 -m black --check .
- python3 -m unittest discover -s examples/tests -p 'test_*.py'