### PR TITLE
Use Trusted Publishing for TestPyPI snapshots

### DIFF
--- a/.github/workflows/publish-testpypi-snapshot.yml
+++ b/.github/workflows/publish-testpypi-snapshot.yml
@@ -8,10 +8,16 @@ on:
         required: false
         default: "0.9.2"
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-n-publish:
     name: Build and publish TestPyPI snapshot
     runs-on: ubuntu-latest
+    environment:
+      name: testpypi
 
     steps:
       - name: Check out repository
@@ -36,7 +42,6 @@ jobs:
       - name: Publish distribution to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.test_pypi_password }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Show published version


### PR DESCRIPTION
Updates the manual TestPyPI snapshot workflow to use PyPI Trusted Publishing via GitHub OIDC instead of the stored test_pypi_password secret.

Changes:
- Adds id-token: write permission
- Uses the testpypi GitHub environment
- Removes the password input from pypa/gh-action-pypi-publish

Before running the workflow after merge, configure a TestPyPI trusted publisher for justmedude/pylotoncycle using workflow publish-testpypi-snapshot.yml and environment testpypi.

Validation:
- python3 -m black --check .
- python3 -m unittest discover -s examples/tests -p 'test_*.py'