### PR TITLE
Clean up workouts CSV example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Python Library for getting your Peloton workout data.
 ## Table of contents
 * [General info](#general-info)
 * [Example Usage](#example-usage)
+* [Testing](#testing)
 
 ## General info
 As someone who wants to see my progress over time, I've been wanting a way
@@ -177,6 +178,50 @@ This package is available via pip install.
 ```
 pip install pylotoncycle
 ```
+
+## Testing
+
+Run the local unit tests with:
+
+```
+python3 -m unittest discover -s examples/tests -p 'test_*.py'
+```
+
+Run the formatter check used by CI with:
+
+```
+python3 -m black --check .
+```
+
+To smoke test against the real Peloton API, set credentials in your
+environment and run the CSV export example:
+
+```
+export PELOTON_USERNAME='your_username_or_email'
+export PELOTON_PASSWORD='your_password'
+
+python3 examples/workouts_to_csv.py \
+  --path /tmp/pyloton-smoke \
+  --timezone America/Los_Angeles
+```
+
+The command should create `/tmp/pyloton-smoke/workouts.csv` and print the
+number of CSV rows downloaded.
+
+To test a TestPyPI snapshot, install the specific dev version from TestPyPI
+before running the smoke test:
+
+```
+python3 -m venv /tmp/pylotoncycle-smoke
+/tmp/pylotoncycle-smoke/bin/python -m pip install --upgrade pip
+/tmp/pylotoncycle-smoke/bin/python -m pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  pylotoncycle==0.9.2.dev3
+```
+
+Replace `0.9.2.dev3` with the version printed by the TestPyPI snapshot
+workflow.
 
 ## TODO
 * Lots more to cover. I want to find the right format for pulling in the

--- a/examples/workouts_to_csv.py
+++ b/examples/workouts_to_csv.py
@@ -1,31 +1,77 @@
+import argparse
 import csv
-from pathlib import Path, PurePath
+import os
+from pathlib import Path
 
 from pylotoncycle import PylotonCycle
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Download Peloton workout history as a CSV file."
+    )
+    parser.add_argument(
+        "--path",
+        default=".",
+        help="Directory where workouts.csv should be written.",
+    )
+    parser.add_argument(
+        "--timezone",
+        default="America/New_York",
+        help="Timezone for the workout history CSV export.",
+    )
+    return parser.parse_args()
+
+
 def GetWorkoutCSV(
     connection: PylotonCycle,
-    path: str = "",
+    path: str = ".",
     timezone: str = "America/New_York",
 ) -> dict:
     workouts_url = f"{connection.base_url}/api/user/{connection.userid}/workout_history_csv?timezone={timezone}"
     resp = connection.s.get(workouts_url, timeout=10)
-    p = (
-        Path(path).joinpath("workouts.csv")
-        if path
-        else PurePath("workouts.csv")
+
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Failed to download workouts CSV: HTTP {resp.status_code}"
+        )
+
+    output_dir = Path(path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir.joinpath("workouts.csv")
+
+    row_count = 0
+    with output_path.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.writer(csv_file)
+        for row in csv.reader(resp.text.splitlines()):
+            writer.writerow(row)
+            row_count += 1
+
+    if row_count == 0:
+        raise RuntimeError("Downloaded workouts CSV was empty.")
+
+    print(f"Workouts saved to {output_path}")
+    return {"response": resp, "path": output_path, "row_count": row_count}
+
+
+def main():
+    args = parse_args()
+    username = os.environ.get("PELOTON_USERNAME")
+    password = os.environ.get("PELOTON_PASSWORD")
+
+    if not username or not password:
+        raise RuntimeError(
+            "Set PELOTON_USERNAME and PELOTON_PASSWORD before running."
+        )
+
+    conn = PylotonCycle(username, password)
+    result = GetWorkoutCSV(
+        connection=conn,
+        path=args.path,
+        timezone=args.timezone,
     )
-    writer = csv.writer(open(p, "w"))
-    for row in csv.reader(resp.text.splitlines()):
-        writer.writerow(row)
-    print(f"Workouts saved to {p}")
-    return {"response": resp, "path": p}
+    print(f"Downloaded {result['row_count']} CSV rows.")
 
 
 if __name__ == "__main__":
-    username = ""
-    password = ""
-
-    conn = PylotonCycle(username, password)
-    r = GetWorkoutCSV(connection=conn, timezone="America/New_York")
+    main()


### PR DESCRIPTION
Makes examples/workouts_to_csv.py suitable for smoke testing by reading credentials from environment variables, using explicit file handling, validating the CSV response, and returning row count metadata.

Adds focused unit tests for successful CSV writing, non-200 responses, and empty CSV responses.

Validation:
- python3 -m black --check .
- python3 -m unittest discover -s examples/tests -p 'test_*.py'