### PR TITLE
Use Trusted Publishing for PyPI releases

### DIFF
--- a/.github/workflows/publish-to-main-pypi.yml
+++ b/.github/workflows/publish-to-main-pypi.yml
@@ -1,27 +1,33 @@
-name: Publish to main PyPi
+name: Publish to PyPI
 
 on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-n-publish:
-    name: Build and publish Python distributions to PyPi
+    name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+
     steps:
-    - uses: actions/checkout@v6
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.x'
-    - name: Install setuptools and wheel
-      run: |
-        python3 -m pip install --upgrade pip
-        pip install --user setuptools wheel
-    - name: Build a binary wheel and a source tarball
-      run: |
-        python3 setup.py sdist bdist_wheel
-    - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.pypi_password }}
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Updates the production PyPI release workflow to use Trusted Publishing via GitHub OIDC instead of the stored pypi_password secret.

Changes:
- Adds id-token: write and contents: read permissions
- Uses the pypi GitHub environment
- Removes the password input from pypa/gh-action-pypi-publish
- Builds with python -m build instead of setup.py sdist bdist_wheel
- Pins release build Python to 3.11

Before creating the next production release, configure a PyPI trusted publisher for justmedude/pylotoncycle using workflow publish-to-main-pypi.yml and environment pypi.

Validation:
- python3 -m black --check .
- python3 -m unittest discover -s examples/tests -p 'test_*.py'