### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/pylotoncycle/__init__.py
+++ b/pylotoncycle/__init__.py
@@ -3,7 +3,7 @@ from .parser import *
 from .AutoRefreshingSession import AutoRefreshingSession
 from .exceptions import PelotonAuthError, PelotonAPIError, PylotonCycleError
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 __all__ = [
     "PylotonCycle",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pylotoncycle",
-    version="0.9.1",
+    version="0.9.2",
     description="Module to access your Peloton workout data",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Bumps the package version in both setup.py and pylotoncycle/__init__.py to 0.9.2 so the next production release can be tagged and published cleanly.

Validation:
- python3 -m black --check .
- python3 -m unittest discover -s examples/tests -p 'test_*.py'