### PR TITLE
Add workout overview and ride details helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,16 @@ workouts = conn.GetRecentWorkouts(5)
 for w in workouts:
     workout_id = w['id']
     resp = conn.GetWorkoutMetricsById(workout_id)
-    pprint.pprint(resp)
+    parsed_metrics = conn.ParseMetricsData(resp)
+    pprint.pprint(parsed_metrics)
 
 save_dict(conn.GetAuthInfo())
 ```
 `workouts` is a list of workouts.
+`ParseMetricsData` converts supported performance graph payloads into a
+dictionary keyed by workout offset seconds. Cycling and other metrics-based
+payloads use the `metrics`, `seconds_since_pedaling_start`, and `segment_list`
+fields. Outdoor GPS payloads use `location_data` and `segment_list`.
 
 An example of a list element
 

--- a/examples/tests/test_pylotoncycle.py
+++ b/examples/tests/test_pylotoncycle.py
@@ -3,6 +3,24 @@ import unittest
 from pylotoncycle import PylotonCycle
 
 
+class FakeResponse:
+    def __init__(self, json_data):
+        self._json_data = json_data
+
+    def json(self):
+        return self._json_data
+
+
+class FakeSession:
+    def __init__(self, json_data):
+        self.json_data = json_data
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return FakeResponse(self.json_data)
+
+
 class TestPylotonCycle(unittest.TestCase):
     def test_recent_workouts_handles_missing_instructor_fields(self):
         client = PylotonCycle.__new__(PylotonCycle)
@@ -18,6 +36,142 @@ class TestPylotonCycle(unittest.TestCase):
 
         self.assertIsNone(result[0]["instructor_name"])
         self.assertEqual(result[0]["performance_graph"], {"x": 1})
+
+    def test_get_user_overview_uses_current_user_and_platform_header(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.s = FakeSession({"workout_counts": {}})
+
+        result = PylotonCycle.GetUserOverviewById(client)
+
+        self.assertEqual(result, {"workout_counts": {}})
+        self.assertEqual(
+            client.s.calls,
+            [
+                (
+                    "https://api.example.com/api/user/user-1/overview",
+                    {
+                        "timeout": 10,
+                        "headers": {"Peloton-Platform": "web"},
+                    },
+                )
+            ],
+        )
+
+    def test_get_user_overview_accepts_userid_and_version(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.s = FakeSession({"streaks": {}})
+
+        result = PylotonCycle.GetUserOverviewById(
+            client,
+            userid="user-2",
+            version=1,
+        )
+
+        self.assertEqual(result, {"streaks": {}})
+        self.assertEqual(
+            client.s.calls[0][0],
+            "https://api.example.com/api/user/user-2/overview?version=1",
+        )
+        self.assertEqual(
+            client.s.calls[0][1]["headers"],
+            {"Peloton-Platform": "web"},
+        )
+
+    def test_get_ride_details_by_id_uses_ride_details_endpoint(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetRideDetailsById(client, "ride-1")
+
+        self.assertEqual(
+            result,
+            {"url": "https://api.example.com/api/ride/ride-1/details"},
+        )
+
+    def test_parse_metrics_data_handles_cycling_payload(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        metrics_data = {
+            "duration": 10,
+            "location_data": [],
+            "segment_list": [
+                {
+                    "name": "Warm Up",
+                    "start_time_offset": 0,
+                    "length": 10,
+                }
+            ],
+            "seconds_since_pedaling_start": [0, 5],
+            "metrics": [
+                {
+                    "slug": "cadence",
+                    "values": [80, 90],
+                },
+                {
+                    "slug": "output",
+                    "values": [120, 150],
+                },
+            ],
+        }
+
+        result = PylotonCycle.ParseMetricsData(client, metrics_data)
+
+        self.assertEqual(
+            result,
+            {
+                0: {
+                    "cadence": 80,
+                    "output": 120,
+                    "segment": "Warm Up",
+                },
+                5: {
+                    "cadence": 90,
+                    "output": 150,
+                    "segment": "Warm Up",
+                },
+            },
+        )
+
+    def test_parse_metrics_data_handles_outdoor_run_payload(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        metrics_data = {
+            "segment_list": [
+                {
+                    "id": "segment-1",
+                    "name": "Run",
+                    "metrics_type": "outdoor_run",
+                }
+            ],
+            "location_data": [
+                {
+                    "segment_id": "segment-1",
+                    "coordinates": [
+                        {
+                            "seconds_offset_from_start": 0,
+                            "latitude": 42.1,
+                            "longitude": -71.2,
+                        }
+                    ],
+                }
+            ],
+        }
+
+        result = PylotonCycle.ParseMetricsData(client, metrics_data)
+
+        self.assertEqual(result[0]["latitude"], 42.1)
+        self.assertEqual(result[0]["longitude"], -71.2)
+        self.assertEqual(result[0]["segment_name"], "Run")
+        self.assertEqual(result[0]["segment_metrics_type"], "outdoor_run")
+
+    def test_parse_metrics_data_rejects_unknown_payload(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+
+        with self.assertRaises(ValueError):
+            PylotonCycle.ParseMetricsData(client, {"duration": 10})
 
 
 if __name__ == "__main__":

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -5,6 +5,7 @@
 
 from .AutoRefreshingSession import AutoRefreshingSession
 from .exceptions import PelotonAuthError
+from .parser import ParseCyclingMetrics, ParseOutdoorRunMetrics
 
 
 class PelotonLoginException(PelotonAuthError):
@@ -75,6 +76,21 @@ class PylotonCycle:
     def GetSettings(self):
         url = "%s/api/user/%s/settings" % (self.base_url, self.userid)
         resp = self.s.get(url, timeout=10).json()
+        return resp
+
+    def GetUserOverviewById(self, userid=None, version=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/overview" % (self.base_url, userid)
+        if version is not None:
+            url = "%s?version=%s" % (url, version)
+
+        resp = self.s.get(
+            url,
+            timeout=10,
+            headers={"Peloton-Platform": "web"},
+        ).json()
         return resp
 
     def GetUrl(self, url):
@@ -167,6 +183,11 @@ class PylotonCycle:
         resp = self.GetUrl(url)
         return resp
 
+    def GetRideDetailsById(self, ride_id):
+        url = "%s/api/ride/%s/details" % (self.base_url, ride_id)
+        resp = self.GetUrl(url)
+        return resp
+
     def GetInstructorById(self, instructor_id):
         if instructor_id in self.instructor_id_dict:
             return self.instructor_id_dict[instructor_id]
@@ -184,8 +205,19 @@ class PylotonCycle:
         return resp
 
     def ParseMetricsData(self, metrics_data):
-        # TODO
-        pass
+        if not isinstance(metrics_data, dict):
+            raise ValueError("metrics_data must be a dict")
+
+        if metrics_data.get("location_data"):
+            return ParseOutdoorRunMetrics(metrics_data)
+
+        if (
+            "metrics" in metrics_data
+            and "seconds_since_pedaling_start" in metrics_data
+        ):
+            return ParseCyclingMetrics(metrics_data)
+
+        raise ValueError("Unsupported metrics data shape")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement ParseMetricsData by dispatching supported performance graph payloads to the existing metric parsers
- add GetUserOverviewById for workout counts, streaks, personal records, and achievements
- add GetRideDetailsById for richer ride/class detail data
- document parsed metrics usage in the README

## Tests
- python3 -m unittest discover -s examples/tests -p 'test_*.py'
- python3 -m black --check .

## Live API checks
- verified GetUserOverviewById returns overview keys including workout_counts, streaks, personal_records, and achievement_counts
- verified GetRideDetailsById returns ride detail keys including ride, playlist, segments, target_metrics_data, target_class_metrics, and averages