### PR TITLE
Harden token auth error handling

### DIFF
--- a/examples/tests/test_auth_exceptions.py
+++ b/examples/tests/test_auth_exceptions.py
@@ -21,6 +21,11 @@ class FakeResponse:
         return self._json_data
 
 
+class InvalidJsonResponse(FakeResponse):
+    def json(self):
+        raise ValueError("not json")
+
+
 class TestAutoRefreshingSession(unittest.TestCase):
     def _make_session(self, **kwargs):
         defaults = {
@@ -50,12 +55,112 @@ class TestAutoRefreshingSession(unittest.TestCase):
             session._login()
 
     @patch.object(auth_session_module.requests, "post")
+    def test_login_with_request_failure_raises_auth_error(self, mock_post):
+        mock_post.side_effect = requests.ConnectionError("network down")
+        session = self._make_session()
+
+        with self.assertRaises(PelotonAuthError):
+            session._login()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_login_with_invalid_json_raises_auth_error(self, mock_post):
+        mock_post.return_value = InvalidJsonResponse()
+        session = self._make_session()
+
+        with self.assertRaises(PelotonAuthError):
+            session._login()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_login_with_missing_token_fields_raises_auth_error(
+        self,
+        mock_post,
+    ):
+        mock_post.return_value = FakeResponse(
+            json_data={"access_token": "new-access"}
+        )
+        session = self._make_session()
+
+        with self.assertRaises(PelotonAuthError):
+            session._login()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_login_updates_auth_state(self, mock_post):
+        mock_post.return_value = FakeResponse(
+            json_data={
+                "access_token": "new-access",
+                "id_token": "new-id",
+                "refresh_token": "new-refresh",
+            }
+        )
+        session = self._make_session()
+
+        session._login()
+
+        self.assertEqual(session.access_token, "new-access")
+        self.assertEqual(session.id_token, "new-id")
+        self.assertEqual(session.last_auth["username"], "user")
+        self.assertEqual(session.last_auth["client_id"], "client")
+
+    @patch.object(auth_session_module.requests, "post")
     def test_refresh_token_falls_back_to_login_failure(self, mock_post):
         mock_post.return_value = FakeResponse(status_code=400)
         session = self._make_session(refresh_token="refresh-token")
 
         with self.assertRaises(PelotonAuthError):
             session._refresh_access_token()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_refresh_token_with_request_failure_raises_auth_error(
+        self,
+        mock_post,
+    ):
+        mock_post.side_effect = requests.Timeout("timed out")
+        session = self._make_session(refresh_token="refresh-token")
+
+        with self.assertRaises(PelotonAuthError):
+            session._refresh_access_token()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_refresh_token_with_invalid_json_raises_auth_error(
+        self,
+        mock_post,
+    ):
+        mock_post.return_value = InvalidJsonResponse()
+        session = self._make_session(refresh_token="refresh-token")
+
+        with self.assertRaises(PelotonAuthError):
+            session._refresh_access_token()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_refresh_token_with_missing_token_fields_raises_auth_error(
+        self,
+        mock_post,
+    ):
+        mock_post.return_value = FakeResponse(
+            json_data={"access_token": "new-access"}
+        )
+        session = self._make_session(refresh_token="refresh-token")
+
+        with self.assertRaises(PelotonAuthError):
+            session._refresh_access_token()
+
+    @patch.object(auth_session_module.requests, "post")
+    def test_refresh_token_updates_auth_state(self, mock_post):
+        mock_post.return_value = FakeResponse(
+            json_data={
+                "access_token": "new-access",
+                "id_token": "new-id",
+                "refresh_token": "new-refresh",
+            }
+        )
+        session = self._make_session(refresh_token="refresh-token")
+
+        session._refresh_access_token()
+
+        self.assertEqual(session.access_token, "new-access")
+        self.assertEqual(session.id_token, "new-id")
+        self.assertEqual(session.last_auth["refresh_token"], "refresh-token")
+        self.assertEqual(session.last_auth["client_id"], "client")
 
     @patch.object(auth_session_module.requests, "post")
     @patch.object(requests.Session, "request")

--- a/pylotoncycle/AutoRefreshingSession.py
+++ b/pylotoncycle/AutoRefreshingSession.py
@@ -69,6 +69,36 @@ class AutoRefreshingSession(requests.Session):
 
         return response
 
+    def _post_token_request(self, payload, error_message):
+        try:
+            return requests.post(self.token_url, json=payload, timeout=10)
+        except requests.RequestException as e:
+            raise PelotonAuthError(error_message) from e
+
+    def _parse_token_response(self, resp, error_message):
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise PelotonAuthError(error_message) from e
+
+        missing_fields = [
+            field
+            for field in ("access_token", "id_token")
+            if not data.get(field)
+        ]
+        if missing_fields:
+            raise PelotonAuthError(
+                "%s Missing expected field(s): %s"
+                % (error_message, ", ".join(missing_fields))
+            )
+
+        return data
+
+    def _update_auth_from_token_data(self, data):
+        self.last_auth = data
+        self.access_token = data["access_token"]
+        self.id_token = data["id_token"]
+
     def _login(self):
         if not self.username or not self.password:
             raise PelotonAuthError(
@@ -82,14 +112,17 @@ class AutoRefreshingSession(requests.Session):
             "username": self.username,
             "password": self.password,
         }
-        resp = requests.post(self.token_url, json=payload, timeout=10)
+        error_message = (
+            "Could not obtain a new bearer token. If using login "
+            "credentials ensure they are correct. If using a refresh token "
+            "please update it."
+        )
+        resp = self._post_token_request(payload, error_message)
 
         if resp.status_code != 200:
-            raise PelotonAuthError(
-                "Could not obtain a new bearer token. If using login credentials ensure they are correct. If using a refresh token please update it."
-            )
+            raise PelotonAuthError(error_message)
 
-        data = resp.json()
+        data = self._parse_token_response(resp, error_message)
         data.update(
             {
                 "username": self.username,
@@ -98,9 +131,7 @@ class AutoRefreshingSession(requests.Session):
                 "redirect_uri": self.redirect_uri,
             }
         )
-        self.last_auth = data
-        self.access_token = data["access_token"]
-        self.id_token = data["id_token"]
+        self._update_auth_from_token_data(data)
 
     def _refresh_access_token(self):
         if not self.refresh_token:
@@ -116,7 +147,8 @@ class AutoRefreshingSession(requests.Session):
             "refresh_token": self.refresh_token,
             "redirect_uri": self.redirect_uri,
         }
-        resp = requests.post(self.token_url, json=payload, timeout=10)
+        error_message = "Could not refresh access token."
+        resp = self._post_token_request(payload, error_message)
 
         if resp.status_code != 200:
             try:
@@ -126,7 +158,7 @@ class AutoRefreshingSession(requests.Session):
                     "Could not refresh access token and fallback login failed."
                 ) from e
             return
-        data = resp.json()
+        data = self._parse_token_response(resp, error_message)
         data.update(
             {
                 "username": self.username,
@@ -136,9 +168,7 @@ class AutoRefreshingSession(requests.Session):
                 "redirect_uri": self.redirect_uri,
             }
         )
-        self.last_auth = data
-        self.access_token = data["access_token"]
-        self.id_token = data["id_token"]
+        self._update_auth_from_token_data(data)
 
     def get_auth_info(self):
         return self.last_auth


### PR DESCRIPTION
## Summary
- wrap token endpoint request failures as PelotonAuthError
- validate token JSON responses and required token fields before updating session state
- share token POST, parse, and auth-state update helpers between login and refresh flows
- expand auth/session failure-path coverage

## Tests
- python3 -m unittest discover -s examples/tests -p 'test_*.py'
- python3 -m black --check .

## Live auth checks
- verified username/password login through PylotonCycle succeeds
- verified forced refresh-token flow succeeds with an intentionally bad access token
- no credentials or token values were printed