### PR TITLE
Bump version to 0.9.3

### DIFF
--- a/.github/workflows/publish-testpypi-snapshot.yml
+++ b/.github/workflows/publish-testpypi-snapshot.yml
@@ -6,7 +6,7 @@ on:
       base_version:
         description: "Base version for the dev snapshot"
         required: false
-        default: "0.9.2"
+        default: "0.9.3"
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ auth.json
 __pycache__/
 *.py[codz]
 *$py.class
+
+# Build artifacts
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ python3 -m venv /tmp/pylotoncycle-smoke
 /tmp/pylotoncycle-smoke/bin/python -m pip install \
   --index-url https://test.pypi.org/simple/ \
   --extra-index-url https://pypi.org/simple/ \
-  pylotoncycle==0.9.2.dev3
+  pylotoncycle==0.9.3.dev3
 ```
 
-Replace `0.9.2.dev3` with the version printed by the TestPyPI snapshot
+Replace `0.9.3.dev3` with the version printed by the TestPyPI snapshot
 workflow.
 
 ## TODO

--- a/pylotoncycle/__init__.py
+++ b/pylotoncycle/__init__.py
@@ -3,7 +3,7 @@ from .parser import *
 from .AutoRefreshingSession import AutoRefreshingSession
 from .exceptions import PelotonAuthError, PelotonAPIError, PylotonCycleError
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 __all__ = [
     "PylotonCycle",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pylotoncycle",
-    version="0.9.2",
+    version="0.9.3",
     description="Module to access your Peloton workout data",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
- bump package version from 0.9.2 to 0.9.3
- update the TestPyPI snapshot default and README example version
- ignore local Python build artifacts

## Tests
- python3 -m unittest discover -s examples/tests -p 'test_*.py'
- python3 -m black --check .
- python3 -m build