### PR TITLE
Add read-only challenge endpoints

### DIFF
--- a/examples/tests/test_pylotoncycle.py
+++ b/examples/tests/test_pylotoncycle.py
@@ -93,6 +93,86 @@ class TestPylotonCycle(unittest.TestCase):
             {"url": "https://api.example.com/api/ride/ride-1/details"},
         )
 
+    def test_get_current_challenges_uses_default_userid(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetCurrentChallenges(client, has_joined=True)
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/user-1/"
+                    "challenges/current?has_joined=true"
+                )
+            },
+        )
+
+    def test_get_upcoming_challenges_accepts_userid(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetUpcomingChallenges(
+            client,
+            has_joined=False,
+            userid="user-2",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/user-2/"
+                    "challenges/upcoming?has_joined=false"
+                )
+            },
+        )
+
+    def test_get_challenge_by_id_uses_challenge_endpoint(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetChallengeById(client, "challenge-1")
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/user-1/"
+                    "challenges/challenge-1"
+                )
+            },
+        )
+
+    def test_get_challenge_friends_by_id_uses_friends_endpoint(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetChallengeFriendsById(
+            client,
+            "challenge-1",
+            userid="user-2",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/user-2/"
+                    "challenges/challenge-1/friends"
+                )
+            },
+        )
+
     def test_parse_metrics_data_handles_cycling_payload(self):
         client = PylotonCycle.__new__(PylotonCycle)
         metrics_data = {

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -93,6 +93,54 @@ class PylotonCycle:
         ).json()
         return resp
 
+    def GetCurrentChallenges(self, has_joined, userid=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/challenges/current?has_joined=%s" % (
+            self.base_url,
+            userid,
+            str(has_joined).lower(),
+        )
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetUpcomingChallenges(self, has_joined, userid=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/challenges/upcoming?has_joined=%s" % (
+            self.base_url,
+            userid,
+            str(has_joined).lower(),
+        )
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetChallengeById(self, challenge_id, userid=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/challenges/%s" % (
+            self.base_url,
+            userid,
+            challenge_id,
+        )
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetChallengeFriendsById(self, challenge_id, userid=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/challenges/%s/friends" % (
+            self.base_url,
+            userid,
+            challenge_id,
+        )
+        resp = self.GetUrl(url)
+        return resp
+
     def GetUrl(self, url):
         resp = self.s.get(url, timeout=10).json()
         return resp


### PR DESCRIPTION
## Summary
- add current and upcoming challenge list helpers
- add challenge detail and challenge friends helpers
- cover URL construction for default and explicit user IDs

## Tests
- python3 -m unittest discover -s examples/tests -p 'test_*.py'
- python3 -m black --check .

## Live API check
- verified current/upcoming challenge list endpoints return the expected container keys: challenges, next, previous, user
- this account returned zero challenges, so detail/friends were validated through unit tests only