### PR TITLE
Add user activity endpoints

### DIFF
--- a/examples/tests/test_pylotoncycle.py
+++ b/examples/tests/test_pylotoncycle.py
@@ -173,6 +173,86 @@ class TestPylotonCycle(unittest.TestCase):
             },
         )
 
+    def test_get_following_by_id_uses_defaults(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetFollowingById(client)
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/user-1/"
+                    "following?page=0&limit=20"
+                )
+            },
+        )
+
+    def test_get_following_by_id_accepts_options(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetFollowingById(
+            client,
+            userid="user-2",
+            page=2,
+            limit=5,
+            joins="relationship",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/user-2/"
+                    "following?page=2&limit=5&joins=relationship"
+                )
+            },
+        )
+
+    def test_get_activity_calendar_by_id_uses_calendar_endpoint(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetActivityCalendarById(
+            client,
+            userid="user-2",
+        )
+
+        self.assertEqual(
+            result,
+            {"url": "https://api.example.com/api/user/user-2/calendar"},
+        )
+
+    def test_get_achievements_by_id_uses_platform_header(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.s = FakeSession({"categories": []})
+
+        result = PylotonCycle.GetAchievementsById(client)
+
+        self.assertEqual(result, {"categories": []})
+        self.assertEqual(
+            client.s.calls,
+            [
+                (
+                    "https://api.example.com/api/user/user-1/achievements",
+                    {
+                        "timeout": 10,
+                        "headers": {"Peloton-Platform": "web"},
+                    },
+                )
+            ],
+        )
+
     def test_parse_metrics_data_handles_cycling_payload(self):
         client = PylotonCycle.__new__(PylotonCycle)
         metrics_data = {

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -141,6 +141,42 @@ class PylotonCycle:
         resp = self.GetUrl(url)
         return resp
 
+    def GetFollowingById(self, userid=None, page=0, limit=20, joins=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/following?page=%s&limit=%s" % (
+            self.base_url,
+            userid,
+            page,
+            limit,
+        )
+        if joins is not None:
+            url = "%s&joins=%s" % (url, joins)
+
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetActivityCalendarById(self, userid=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/calendar" % (self.base_url, userid)
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetAchievementsById(self, userid=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/achievements" % (self.base_url, userid)
+        resp = self.s.get(
+            url,
+            timeout=10,
+            headers={"Peloton-Platform": "web"},
+        ).json()
+        return resp
+
     def GetUrl(self, url):
         resp = self.s.get(url, timeout=10).json()
         return resp


### PR DESCRIPTION
## Summary
- add following, activity calendar, and achievements helpers
- support following pagination and optional joins
- use the required Peloton-Platform header for achievements
- add unit coverage for URL/header construction

## Tests
- python3 -m unittest discover -s examples/tests -p 'test_*.py'
- python3 -m black --check .

## Live API check
- verified following returns result-list keys and data
- verified activity calendar returns months
- verified achievements returns categories