### PR TITLE
Add Peloton reference endpoints

### DIFF
--- a/examples/tests/test_pylotoncycle.py
+++ b/examples/tests/test_pylotoncycle.py
@@ -253,6 +253,74 @@ class TestPylotonCycle(unittest.TestCase):
             ],
         )
 
+    def test_get_browse_categories_uses_default_library_type(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetBrowseCategories(client)
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/browse_categories"
+                    "?library_type=on_demand"
+                )
+            },
+        )
+
+    def test_get_instructors_uses_page_and_limit(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetInstructors(client, page=2, limit=25)
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/instructor?page=2&limit=25"
+                )
+            },
+        )
+
+    def test_get_ride_metadata_mappings_uses_expected_endpoint(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetRideMetadataMappings(client)
+
+        self.assertEqual(
+            result,
+            {"url": ("https://api.example.com/api/ride/metadata_mappings")},
+        )
+
+    def test_get_ride_filters_supports_optional_query_params(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetRideFilters(
+            client,
+            library_type="on_demand",
+            browse_category="cycling",
+            include_icon_images=True,
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/ride/filters"
+                    "?library_type=on_demand&browse_category=cycling"
+                    "&include_icon_images=true"
+                )
+            },
+        )
+
     def test_parse_metrics_data_handles_cycling_payload(self):
         client = PylotonCycle.__new__(PylotonCycle)
         metrics_data = {

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -177,6 +177,54 @@ class PylotonCycle:
         ).json()
         return resp
 
+    def GetBrowseCategories(self, library_type="on_demand"):
+        url = "%s/api/browse_categories?library_type=%s" % (
+            self.base_url,
+            library_type,
+        )
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetInstructors(self, page=0, limit=100):
+        url = "%s/api/instructor?page=%s&limit=%s" % (
+            self.base_url,
+            page,
+            limit,
+        )
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetRideMetadataMappings(self):
+        url = "%s/api/ride/metadata_mappings" % (self.base_url)
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetRideFilters(
+        self,
+        library_type=None,
+        browse_category=None,
+        include_icon_images=None,
+    ):
+        url = "%s/api/ride/filters" % (self.base_url)
+        query_params = []
+
+        if library_type is not None:
+            query_params.append("library_type=%s" % library_type)
+
+        if browse_category is not None:
+            query_params.append("browse_category=%s" % browse_category)
+
+        if include_icon_images is not None:
+            query_params.append(
+                "include_icon_images=%s" % str(include_icon_images).lower()
+            )
+
+        if query_params:
+            url = "%s?%s" % (url, "&".join(query_params))
+
+        resp = self.GetUrl(url)
+        return resp
+
     def GetUrl(self, url):
         resp = self.s.get(url, timeout=10).json()
         return resp


### PR DESCRIPTION
Adds the reference endpoints from the unofficial spec:

- `GetBrowseCategories(library_type="on_demand")`
- `GetInstructors(page=0, limit=100)`
- `GetRideMetadataMappings()`
- `GetRideFilters(...)`

Includes focused unit tests for URL construction and query parameters. `PLAN.md` remains local-only and is not part of the PR.