### PR TITLE
Add ride discovery endpoints

### DIFF
--- a/examples/tests/test_pylotoncycle.py
+++ b/examples/tests/test_pylotoncycle.py
@@ -93,6 +93,151 @@ class TestPylotonCycle(unittest.TestCase):
             {"url": "https://api.example.com/api/ride/ride-1/details"},
         )
 
+    def test_get_ride_details_by_id_accepts_stream_source(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetRideDetailsById(
+            client,
+            "ride-1",
+            stream_source="web",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/ride/ride-1/details"
+                    "?stream_source=web"
+                )
+            },
+        )
+
+    def test_get_archived_rides_uses_defaults(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetArchivedRides(client)
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/v2/ride/archived"
+                    "?limit=100&page=0"
+                )
+            },
+        )
+
+    def test_get_archived_rides_supports_query_params(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetArchivedRides(
+            client,
+            browse_category="cycling",
+            limit=25,
+            content_format="audio",
+            page=3,
+            sort_by="trending",
+            is_favorite_ride=True,
+            desc=False,
+            instructor_id="instructor-1",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/v2/ride/archived"
+                    "?browse_category=cycling&limit=25&content_format=audio"
+                    "&page=3&sort_by=trending&is_favorite_ride=true"
+                    "&desc=false&instructor_id=instructor-1"
+                )
+            },
+        )
+
+    def test_get_live_rides_supports_query_params(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetLiveRides(
+            client,
+            exclude_complete=True,
+            content_provider="peloton",
+            browse_category="cycling",
+            start="2026-06-06T00:00:00Z",
+            limit=10,
+            end="2026-06-06T01:00:00Z",
+            exclude_live_in_studio_only=False,
+            ignore_class_language_preferences=True,
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/v3/ride/live"
+                    "?exclude_complete=true&content_provider=peloton"
+                    "&browse_category=cycling&start=2026-06-06T00:00:00Z"
+                    "&limit=10&end=2026-06-06T01:00:00Z"
+                    "&exclude_live_in_studio_only=false"
+                    "&ignore_class_language_preferences=true"
+                )
+            },
+        )
+
+    def test_get_recent_following_workouts_by_ride_id_uses_defaults(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetRecentFollowingWorkoutsByRideId(
+            client,
+            "ride-1",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/ride/ride-1/"
+                    "recent_following_workouts?limit=20&page=0"
+                )
+            },
+        )
+
+    def test_get_recent_following_workouts_by_ride_id_supports_query_params(
+        self,
+    ):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetRecentFollowingWorkoutsByRideId(
+            client,
+            "ride-1",
+            joins="ride,ride.instructor",
+            limit=5,
+            page=2,
+            sort_by="-created_at",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/ride/ride-1/"
+                    "recent_following_workouts?joins=ride,ride.instructor"
+                    "&limit=5&page=2&sort_by=-created_at"
+                )
+            },
+        )
+
     def test_get_current_challenges_uses_default_userid(self):
         client = PylotonCycle.__new__(PylotonCycle)
         client.base_url = "https://api.example.com"

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -315,8 +315,140 @@ class PylotonCycle:
         resp = self.GetUrl(url)
         return resp
 
-    def GetRideDetailsById(self, ride_id):
+    def GetRideDetailsById(self, ride_id, stream_source=None):
         url = "%s/api/ride/%s/details" % (self.base_url, ride_id)
+        if stream_source is not None:
+            url = "%s?stream_source=%s" % (url, stream_source)
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetArchivedRides(
+        self,
+        browse_category=None,
+        limit=100,
+        content_format=None,
+        page=0,
+        sort_by=None,
+        is_favorite_ride=None,
+        desc=None,
+        instructor_id=None,
+    ):
+        url = "%s/api/v2/ride/archived" % (self.base_url)
+        query_params = []
+
+        if browse_category is not None:
+            query_params.append("browse_category=%s" % browse_category)
+
+        if limit is not None:
+            query_params.append("limit=%s" % limit)
+
+        if content_format is not None:
+            query_params.append("content_format=%s" % content_format)
+
+        if page is not None:
+            query_params.append("page=%s" % page)
+
+        if sort_by is not None:
+            query_params.append("sort_by=%s" % sort_by)
+
+        if is_favorite_ride is not None:
+            query_params.append(
+                "is_favorite_ride=%s" % str(is_favorite_ride).lower()
+            )
+
+        if desc is not None:
+            query_params.append("desc=%s" % str(desc).lower())
+
+        if instructor_id is not None:
+            query_params.append("instructor_id=%s" % instructor_id)
+
+        if query_params:
+            url = "%s?%s" % (url, "&".join(query_params))
+
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetLiveRides(
+        self,
+        exclude_complete=None,
+        content_provider=None,
+        browse_category=None,
+        start=None,
+        limit=None,
+        end=None,
+        exclude_live_in_studio_only=None,
+        ignore_class_language_preferences=None,
+    ):
+        url = "%s/api/v3/ride/live" % (self.base_url)
+        query_params = []
+
+        if exclude_complete is not None:
+            query_params.append(
+                "exclude_complete=%s" % str(exclude_complete).lower()
+            )
+
+        if content_provider is not None:
+            query_params.append("content_provider=%s" % content_provider)
+
+        if browse_category is not None:
+            query_params.append("browse_category=%s" % browse_category)
+
+        if start is not None:
+            query_params.append("start=%s" % start)
+
+        if limit is not None:
+            query_params.append("limit=%s" % limit)
+
+        if end is not None:
+            query_params.append("end=%s" % end)
+
+        if exclude_live_in_studio_only is not None:
+            query_params.append(
+                "exclude_live_in_studio_only=%s"
+                % str(exclude_live_in_studio_only).lower()
+            )
+
+        if ignore_class_language_preferences is not None:
+            query_params.append(
+                "ignore_class_language_preferences=%s"
+                % str(ignore_class_language_preferences).lower()
+            )
+
+        if query_params:
+            url = "%s?%s" % (url, "&".join(query_params))
+
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetRecentFollowingWorkoutsByRideId(
+        self,
+        ride_id,
+        joins=None,
+        limit=20,
+        page=0,
+        sort_by=None,
+    ):
+        url = "%s/api/ride/%s/recent_following_workouts" % (
+            self.base_url,
+            ride_id,
+        )
+        query_params = []
+
+        if joins is not None:
+            query_params.append("joins=%s" % joins)
+
+        if limit is not None:
+            query_params.append("limit=%s" % limit)
+
+        if page is not None:
+            query_params.append("page=%s" % page)
+
+        if sort_by is not None:
+            query_params.append("sort_by=%s" % sort_by)
+
+        if query_params:
+            url = "%s?%s" % (url, "&".join(query_params))
+
         resp = self.GetUrl(url)
         return resp
 


### PR DESCRIPTION
Adds ride discovery support from the unofficial spec:

- `GetArchivedRides(...)`
- `GetLiveRides(...)`
- `GetRecentFollowingWorkoutsByRideId(ride_id, ...)`
- `GetRideDetailsById(ride_id, stream_source=None)`

Includes focused unit tests for URL construction and query parameters. `PLAN.md` remains local-only and is not part of the PR.