### PR TITLE
Add low-risk account endpoints

### DIFF
--- a/examples/tests/test_pylotoncycle.py
+++ b/examples/tests/test_pylotoncycle.py
@@ -238,6 +238,74 @@ class TestPylotonCycle(unittest.TestCase):
             },
         )
 
+    def test_search_users_uses_default_limit(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.SearchUsers(client, "alice")
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/search"
+                    "?user_query=alice&limit=40"
+                )
+            },
+        )
+
+    def test_get_user_by_id_or_username_accepts_is_onboarded(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetUserByIdOrUsername(
+            client,
+            "alice",
+            is_onboarded="true",
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/alice"
+                    "?is_onboarded=true"
+                )
+            },
+        )
+
+    def test_get_subscriptions_uses_expected_endpoint(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetSubscriptions(client)
+
+        self.assertEqual(
+            result,
+            {"url": "https://api.example.com/api/v2/user/subscriptions"},
+        )
+
+    def test_get_referral_history_by_id_uses_default_userid(self):
+        client = PylotonCycle.__new__(PylotonCycle)
+        client.base_url = "https://api.example.com"
+        client.userid = "user-1"
+        client.GetUrl = lambda url: {"url": url}
+
+        result = PylotonCycle.GetReferralHistoryById(client)
+
+        self.assertEqual(
+            result,
+            {
+                "url": (
+                    "https://api.example.com/api/user/user-1/"
+                    "referral_history"
+                )
+            },
+        )
+
     def test_get_current_challenges_uses_default_userid(self):
         client = PylotonCycle.__new__(PylotonCycle)
         client.base_url = "https://api.example.com"

--- a/pylotoncycle/pylotoncycle.py
+++ b/pylotoncycle/pylotoncycle.py
@@ -225,6 +225,37 @@ class PylotonCycle:
         resp = self.GetUrl(url)
         return resp
 
+    def SearchUsers(self, user_query, limit=40):
+        url = "%s/api/user/search?user_query=%s&limit=%s" % (
+            self.base_url,
+            user_query,
+            limit,
+        )
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetUserByIdOrUsername(self, user_name_or_id, is_onboarded=None):
+        url = "%s/api/user/%s" % (self.base_url, user_name_or_id)
+
+        if is_onboarded is not None:
+            url = "%s?is_onboarded=%s" % (url, is_onboarded)
+
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetSubscriptions(self):
+        url = "%s/api/v2/user/subscriptions" % (self.base_url)
+        resp = self.GetUrl(url)
+        return resp
+
+    def GetReferralHistoryById(self, userid=None):
+        if userid is None:
+            userid = self.userid
+
+        url = "%s/api/user/%s/referral_history" % (self.base_url, userid)
+        resp = self.GetUrl(url)
+        return resp
+
     def GetUrl(self, url):
         resp = self.s.get(url, timeout=10).json()
         return resp


### PR DESCRIPTION
Adds low-risk account endpoints from the unofficial spec:

- `SearchUsers(query, limit=40)`
- `GetUserByIdOrUsername(user_name_or_id, is_onboarded=None)`
- `GetSubscriptions()`
- `GetReferralHistoryById(userid=None)`

Includes focused unit tests for URL construction and query parameters. Live smoke checks confirmed the wrappers work against the current API surface; a very short search query returned an API error shape, which is expected server-side behavior and not a client failure. `PLAN.md` remains local-only and is not part of the PR.