### PR TITLE
Bump release version to 0.9.5

### DIFF
--- a/.github/workflows/publish-testpypi-snapshot.yml
+++ b/.github/workflows/publish-testpypi-snapshot.yml
@@ -6,7 +6,11 @@ on:
       base_version:
         description: "Base version for the dev snapshot"
         required: false
-        default: "0.9.4"
+        default: "0.9.5"
+      dev_version:
+        description: "Dev suffix for the snapshot"
+        required: false
+        default: "1"
 
 permissions:
   contents: read
@@ -30,7 +34,7 @@ jobs:
 
       - name: Set snapshot version
         run: |
-          VERSION="${{ inputs.base_version }}.dev${GITHUB_RUN_NUMBER}"
+          VERSION="${{ inputs.base_version }}.dev${{ inputs.dev_version }}"
           python scripts/set_version.py "$VERSION"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 

--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ python3 -m venv /tmp/pylotoncycle-smoke
 /tmp/pylotoncycle-smoke/bin/python -m pip install \
   --index-url https://test.pypi.org/simple/ \
   --extra-index-url https://pypi.org/simple/ \
-  pylotoncycle==0.9.4.dev3
+  pylotoncycle==0.9.5.dev1
 ```
 
-Replace `0.9.4.dev3` with the version printed by the TestPyPI snapshot
+Replace `0.9.5.dev1` with the version printed by the TestPyPI snapshot
 workflow.
 
 ## TODO

--- a/pylotoncycle/__init__.py
+++ b/pylotoncycle/__init__.py
@@ -3,7 +3,7 @@ from .parser import *
 from .AutoRefreshingSession import AutoRefreshingSession
 from .exceptions import PelotonAuthError, PelotonAPIError, PylotonCycleError
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 
 __all__ = [
     "PylotonCycle",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pylotoncycle",
-    version="0.9.4",
+    version="0.9.5",
     description="Module to access your Peloton workout data",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Bumps the package release version to `0.9.5` and resets the TestPyPI snapshot default to `dev1`.

Included:
- `setup.py`
- `pylotoncycle/__init__.py`
- `.github/workflows/publish-testpypi-snapshot.yml`
- `README.md`

The snapshot workflow now uses an explicit `dev_version` input defaulting to `1`, so the published snapshot version starts at `0.9.5.dev1`. `PLAN.md` remains local-only and is not part of the PR.